### PR TITLE
Vendor aws middleware to avoid usage of private package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.22.2
 
 require (
 	github.com/aws/aws-sdk-go v1.53.4
-	github.com/aws/aws-sdk-go-v2 v1.27.0
-	github.com/aws/smithy-go v1.20.2
+	github.com/aws/aws-sdk-go-v2 v1.32.4
+	github.com/aws/smithy-go v1.22.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/samber/lo v1.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,12 @@ github.com/aws/aws-sdk-go v1.53.4 h1:SNCHaUqS3KMNl6fzwUv+iNl3VT9Y5ULfbbk6z4EMSnY
 github.com/aws/aws-sdk-go v1.53.4/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.27.0 h1:7bZWKoXhzI+mMR/HjdMx8ZCC5+6fY0lS5tr0bbgiLlo=
 github.com/aws/aws-sdk-go-v2 v1.27.0/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
+github.com/aws/aws-sdk-go-v2 v1.32.4 h1:S13INUiTxgrPueTmrm5DZ+MiAo99zYzHEFh1UNkOxNE=
+github.com/aws/aws-sdk-go-v2 v1.32.4/go.mod h1:2SK5n0a2karNTv5tbP1SjsX0uhttou00v/HpXKM1ZUo=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/aws/smithy-go v1.22.0 h1:uunKnWlcoL3zO7q+gG2Pk53joueEOsnNB28QdMsmiMM=
+github.com/aws/smithy-go v1.22.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/v2/awsmetrics/metrics.go
+++ b/v2/awsmetrics/metrics.go
@@ -1,0 +1,320 @@
+// Package metrics implements metrics gathering for SDK development purposes.
+//
+// This package is designated as private and is intended for use only by the
+// AWS client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+package awsmetrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+)
+
+const (
+	// ServiceIDKey is the key for the service ID metric.
+	ServiceIDKey = "ServiceId"
+	// OperationNameKey is the key for the operation name metric.
+	OperationNameKey = "OperationName"
+	// ClientRequestIDKey is the key for the client request ID metric.
+	ClientRequestIDKey = "ClientRequestId"
+	// APICallDurationKey is the key for the API call duration metric.
+	APICallDurationKey = "ApiCallDuration"
+	// APICallSuccessfulKey is the key for the API call successful metric.
+	APICallSuccessfulKey = "ApiCallSuccessful"
+	// MarshallingDurationKey is the key for the marshalling duration metric.
+	MarshallingDurationKey = "MarshallingDuration"
+	// InThroughputKey is the key for the input throughput metric.
+	InThroughputKey = "InThroughput"
+	// OutThroughputKey is the key for the output throughput metric.
+	OutThroughputKey = "OutThroughput"
+	// RetryCountKey is the key for the retry count metric.
+	RetryCountKey = "RetryCount"
+	// HTTPStatusCodeKey is the key for the HTTP status code metric.
+	HTTPStatusCodeKey = "HttpStatusCode"
+	// AWSExtendedRequestIDKey is the key for the AWS extended request ID metric.
+	AWSExtendedRequestIDKey = "AwsExtendedRequestId"
+	// AWSRequestIDKey is the key for the AWS request ID metric.
+	AWSRequestIDKey = "AwsRequestId"
+	// BackoffDelayDurationKey is the key for the backoff delay duration metric.
+	BackoffDelayDurationKey = "BackoffDelayDuration"
+	// StreamThroughputKey is the key for the stream throughput metric.
+	StreamThroughputKey = "Throughput"
+	// ConcurrencyAcquireDurationKey is the key for the concurrency acquire duration metric.
+	ConcurrencyAcquireDurationKey = "ConcurrencyAcquireDuration"
+	// PendingConcurrencyAcquiresKey is the key for the pending concurrency acquires metric.
+	PendingConcurrencyAcquiresKey = "PendingConcurrencyAcquires"
+	// SigningDurationKey is the key for the signing duration metric.
+	SigningDurationKey = "SigningDuration"
+	// UnmarshallingDurationKey is the key for the unmarshalling duration metric.
+	UnmarshallingDurationKey = "UnmarshallingDuration"
+	// TimeToFirstByteKey is the key for the time to first byte metric.
+	TimeToFirstByteKey = "TimeToFirstByte"
+	// ServiceCallDurationKey is the key for the service call duration metric.
+	ServiceCallDurationKey = "ServiceCallDuration"
+	// EndpointResolutionDurationKey is the key for the endpoint resolution duration metric.
+	EndpointResolutionDurationKey = "EndpointResolutionDuration"
+	// AttemptNumberKey is the key for the attempt number metric.
+	AttemptNumberKey = "AttemptNumber"
+	// MaxConcurrencyKey is the key for the max concurrency metric.
+	MaxConcurrencyKey = "MaxConcurrency"
+	// AvailableConcurrencyKey is the key for the available concurrency metric.
+	AvailableConcurrencyKey = "AvailableConcurrency"
+)
+
+// MetricPublisher provides the interface to provide custom MetricPublishers.
+// PostRequestMetrics will be invoked by the MetricCollection middleware to post request.
+// PostStreamMetrics will be invoked by ReadCloserWithMetrics to post stream awsmetrics.
+type MetricPublisher interface {
+	PostRequestMetrics(*MetricData) error
+	PostStreamMetrics(*MetricData) error
+}
+
+// Serializer provides the interface to provide custom Serializers.
+// Serialize will transform any input object in its corresponding string representation.
+type Serializer interface {
+	Serialize(obj interface{}) (string, error)
+}
+
+// DefaultSerializer is an implementation of the Serializer interface.
+type DefaultSerializer struct{}
+
+// Serialize uses the default JSON serializer to obtain the string representation of an object.
+func (DefaultSerializer) Serialize(obj interface{}) (string, error) {
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+type metricContextKey struct{}
+
+// MetricContext contains fields to store metric-related information.
+type MetricContext struct {
+	connectionCounter *SharedConnectionCounter
+	publisher         MetricPublisher
+	data              *MetricData
+}
+
+// MetricData stores the collected metric data.
+type MetricData struct {
+	RequestStartTime           time.Time
+	RequestEndTime             time.Time
+	APICallDuration            time.Duration
+	SerializeStartTime         time.Time
+	SerializeEndTime           time.Time
+	MarshallingDuration        time.Duration
+	ResolveEndpointStartTime   time.Time
+	ResolveEndpointEndTime     time.Time
+	EndpointResolutionDuration time.Duration
+	GetIdentityStartTime       time.Time
+	GetIdentityEndTime         time.Time
+	InThroughput               float64
+	OutThroughput              float64
+	RetryCount                 int
+	Success                    uint8
+	StatusCode                 int
+	ClientRequestID            string
+	ServiceID                  string
+	OperationName              string
+	PartitionID                string
+	Region                     string
+	UserAgent                  string
+	RequestContentLength       int64
+	Stream                     StreamMetrics
+	Attempts                   []AttemptMetrics
+}
+
+// StreamMetrics stores metrics related to streaming data.
+type StreamMetrics struct {
+	ReadDuration time.Duration
+	ReadBytes    int64
+	Throughput   float64
+}
+
+// AttemptMetrics stores metrics related to individual attempts.
+type AttemptMetrics struct {
+	ServiceCallStart           time.Time
+	ServiceCallEnd             time.Time
+	ServiceCallDuration        time.Duration
+	FirstByteTime              time.Time
+	TimeToFirstByte            time.Duration
+	ConnRequestedTime          time.Time
+	ConnObtainedTime           time.Time
+	ConcurrencyAcquireDuration time.Duration
+	SignStartTime              time.Time
+	SignEndTime                time.Time
+	SigningDuration            time.Duration
+	DeserializeStartTime       time.Time
+	DeserializeEndTime         time.Time
+	UnMarshallingDuration      time.Duration
+	RetryDelay                 time.Duration
+	ResponseContentLength      int64
+	StatusCode                 int
+	RequestID                  string
+	ExtendedRequestID          string
+	HTTPClient                 string
+	MaxConcurrency             int
+	PendingConnectionAcquires  int
+	AvailableConcurrency       int
+	ActiveRequests             int
+	ReusedConnection           bool
+}
+
+// Data returns the MetricData associated with the MetricContext.
+func (mc *MetricContext) Data() *MetricData {
+	return mc.data
+}
+
+// ConnectionCounter returns the SharedConnectionCounter associated with the MetricContext.
+func (mc *MetricContext) ConnectionCounter() *SharedConnectionCounter {
+	return mc.connectionCounter
+}
+
+// Publisher returns the MetricPublisher associated with the MetricContext.
+func (mc *MetricContext) Publisher() MetricPublisher {
+	return mc.publisher
+}
+
+// ComputeRequestMetrics calculates and populates derived metrics based on the collected data.
+func (md *MetricData) ComputeRequestMetrics() {
+
+	for idx := range md.Attempts {
+		attempt := &md.Attempts[idx]
+		attempt.ConcurrencyAcquireDuration = attempt.ConnObtainedTime.Sub(attempt.ConnRequestedTime)
+		attempt.SigningDuration = attempt.SignEndTime.Sub(attempt.SignStartTime)
+		attempt.UnMarshallingDuration = attempt.DeserializeEndTime.Sub(attempt.DeserializeStartTime)
+		attempt.TimeToFirstByte = attempt.FirstByteTime.Sub(attempt.ServiceCallStart)
+		attempt.ServiceCallDuration = attempt.ServiceCallEnd.Sub(attempt.ServiceCallStart)
+	}
+
+	md.APICallDuration = md.RequestEndTime.Sub(md.RequestStartTime)
+	md.MarshallingDuration = md.SerializeEndTime.Sub(md.SerializeStartTime)
+	md.EndpointResolutionDuration = md.ResolveEndpointEndTime.Sub(md.ResolveEndpointStartTime)
+
+	md.RetryCount = len(md.Attempts) - 1
+
+	latestAttempt, err := md.LatestAttempt()
+
+	if err != nil {
+		fmt.Printf("error retrieving attempts data due to: %s. Skipping Throughput metrics", err.Error())
+	} else {
+
+		md.StatusCode = latestAttempt.StatusCode
+
+		if md.Success == 1 {
+			if latestAttempt.ResponseContentLength > 0 && latestAttempt.ServiceCallDuration > 0 {
+				md.InThroughput = float64(latestAttempt.ResponseContentLength) / latestAttempt.ServiceCallDuration.Seconds()
+			}
+			if md.RequestContentLength > 0 && latestAttempt.ServiceCallDuration > 0 {
+				md.OutThroughput = float64(md.RequestContentLength) / latestAttempt.ServiceCallDuration.Seconds()
+			}
+		}
+	}
+}
+
+// LatestAttempt returns the latest attempt awsmetrics.
+// It returns an error if no attempts are initialized.
+func (md *MetricData) LatestAttempt() (*AttemptMetrics, error) {
+	if md.Attempts == nil || len(md.Attempts) == 0 {
+		return nil, fmt.Errorf("no attempts initialized. NewAttempt() should be called first")
+	}
+	return &md.Attempts[len(md.Attempts)-1], nil
+}
+
+// NewAttempt initializes new attempt awsmetrics.
+func (md *MetricData) NewAttempt() {
+	if md.Attempts == nil {
+		md.Attempts = []AttemptMetrics{}
+	}
+	md.Attempts = append(md.Attempts, AttemptMetrics{})
+}
+
+// SharedConnectionCounter is a counter shared across API calls.
+type SharedConnectionCounter struct {
+	mu sync.Mutex
+
+	activeRequests           int
+	pendingConnectionAcquire int
+}
+
+// ActiveRequests returns the count of active requests.
+func (cc *SharedConnectionCounter) ActiveRequests() int {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	return cc.activeRequests
+}
+
+// PendingConnectionAcquire returns the count of pending connection acquires.
+func (cc *SharedConnectionCounter) PendingConnectionAcquire() int {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	return cc.pendingConnectionAcquire
+}
+
+// AddActiveRequest increments the count of active requests.
+func (cc *SharedConnectionCounter) AddActiveRequest() {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	cc.activeRequests++
+}
+
+// RemoveActiveRequest decrements the count of active requests.
+func (cc *SharedConnectionCounter) RemoveActiveRequest() {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	cc.activeRequests--
+}
+
+// AddPendingConnectionAcquire increments the count of pending connection acquires.
+func (cc *SharedConnectionCounter) AddPendingConnectionAcquire() {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	cc.pendingConnectionAcquire++
+}
+
+// RemovePendingConnectionAcquire decrements the count of pending connection acquires.
+func (cc *SharedConnectionCounter) RemovePendingConnectionAcquire() {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	cc.pendingConnectionAcquire--
+}
+
+// InitMetricContext initializes the metric context with the provided counter and publisher.
+// It returns the updated context.
+func InitMetricContext(
+	ctx context.Context, counter *SharedConnectionCounter, publisher MetricPublisher,
+) context.Context {
+	if middleware.GetStackValue(ctx, metricContextKey{}) == nil {
+		ctx = middleware.WithStackValue(ctx, metricContextKey{}, &MetricContext{
+			connectionCounter: counter,
+			publisher:         publisher,
+			data: &MetricData{
+				Attempts: []AttemptMetrics{},
+				Stream:   StreamMetrics{},
+			},
+		})
+	}
+	return ctx
+}
+
+// Context returns the metric context from the given context.
+// It returns nil if the metric context is not found.
+func Context(ctx context.Context) *MetricContext {
+	mctx := middleware.GetStackValue(ctx, metricContextKey{})
+	if mctx == nil {
+		return nil
+	}
+	return mctx.(*MetricContext)
+}

--- a/v2/awsmetrics/middleware/configuration.go
+++ b/v2/awsmetrics/middleware/configuration.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+func WithMetricMiddlewares(
+	publisher awsmetrics.MetricPublisher, client *http.Client,
+) func(stack *middleware.Stack) error {
+	connectionCounter := &awsmetrics.SharedConnectionCounter{}
+	return func(stack *middleware.Stack) error {
+		if err := stack.Initialize.Add(GetSetupMetricCollectionMiddleware(connectionCounter, publisher), middleware.Before); err != nil {
+			return err
+		}
+		if err := stack.Serialize.Add(GetRecordStackSerializeStartMiddleware(), middleware.Before); err != nil {
+			return err
+		}
+		if err := stack.Serialize.Add(GetRecordStackSerializeEndMiddleware(), middleware.After); err != nil {
+			return err
+		}
+		if err := stack.Finalize.Insert(GetRecordEndpointResolutionStartMiddleware(), "ResolveEndpointV2", middleware.Before); err != nil {
+			return err
+		}
+		if err := stack.Finalize.Insert(GetRecordEndpointResolutionEndMiddleware(), "ResolveEndpointV2", middleware.After); err != nil {
+			return err
+		}
+		if err := stack.Build.Add(GetWrapDataStreamMiddleware(), middleware.After); err != nil {
+			return err
+		}
+		if err := stack.Finalize.Add(GetRegisterRequestMetricContextMiddleware(), middleware.Before); err != nil {
+			return err
+		}
+		if err := stack.Finalize.Insert(GetRegisterAttemptMetricContextMiddleware(), "Retry", middleware.After); err != nil {
+			return err
+		}
+		if err := stack.Finalize.Add(GetHttpMetricMiddleware(client), middleware.After); err != nil {
+			return err
+		}
+		if err := stack.Deserialize.Add(GetRecordStackDeserializeStartMiddleware(), middleware.After); err != nil {
+			return err
+		}
+		if err := stack.Deserialize.Add(GetRecordStackDeserializeEndMiddleware(), middleware.Before); err != nil {
+			return err
+		}
+		if err := stack.Deserialize.Insert(GetTransportMetricsMiddleware(), "StackDeserializeStart", middleware.After); err != nil {
+			return err
+		}
+		if err := timeGetIdentity(stack); err != nil {
+			return err
+		}
+		if err := timeSigning(stack); err != nil {
+			return err
+		}
+		if err := stack.Build.Add(&captureUserAgent{}, middleware.After); err != nil {
+			return err
+		}
+		return nil
+	}
+}

--- a/v2/awsmetrics/middleware/endpoint_resolution_end.go
+++ b/v2/awsmetrics/middleware/endpoint_resolution_end.go
@@ -1,0 +1,49 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type EndpointResolutionEnd struct{}
+
+func GetRecordEndpointResolutionEndMiddleware() *EndpointResolutionEnd {
+	return &EndpointResolutionEnd{}
+}
+
+func (m *EndpointResolutionEnd) ID() string {
+	return "EndpointResolutionEnd"
+}
+
+// Deprecated: Endpoint resolution now occurs in Finalize. The ResolveEndpoint
+// middleware remains in serialize but is largely a no-op.
+func (m *EndpointResolutionEnd) HandleSerialize(
+	ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler,
+) (
+	out middleware.SerializeOutput, metadata middleware.Metadata, err error,
+) {
+
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().ResolveEndpointEndTime = time.Now().UTC()
+
+	out, metadata, err = next.HandleSerialize(ctx, in)
+
+	return out, metadata, err
+}
+
+func (m *EndpointResolutionEnd) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	middleware.FinalizeOutput, middleware.Metadata, error,
+) {
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().ResolveEndpointEndTime = time.Now().UTC()
+	return next.HandleFinalize(ctx, in)
+}

--- a/v2/awsmetrics/middleware/endpoint_resolution_start.go
+++ b/v2/awsmetrics/middleware/endpoint_resolution_start.go
@@ -1,0 +1,49 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type EndpointResolutionStart struct{}
+
+func GetRecordEndpointResolutionStartMiddleware() *EndpointResolutionStart {
+	return &EndpointResolutionStart{}
+}
+
+func (m *EndpointResolutionStart) ID() string {
+	return "EndpointResolutionStart"
+}
+
+// Deprecated: Endpoint resolution now occurs in Finalize. The ResolveEndpoint
+// middleware remains in serialize but is largely a no-op.
+func (m *EndpointResolutionStart) HandleSerialize(
+	ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler,
+) (
+	out middleware.SerializeOutput, metadata middleware.Metadata, err error,
+) {
+
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().ResolveEndpointStartTime = time.Now().UTC()
+
+	out, metadata, err = next.HandleSerialize(ctx, in)
+
+	return out, metadata, err
+}
+
+func (m *EndpointResolutionStart) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	middleware.FinalizeOutput, middleware.Metadata, error,
+) {
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().ResolveEndpointStartTime = time.Now().UTC()
+	return next.HandleFinalize(ctx, in)
+}

--- a/v2/awsmetrics/middleware/http.go
+++ b/v2/awsmetrics/middleware/http.go
@@ -1,0 +1,153 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptrace"
+	"reflect"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+const (
+	idleConnFieldName     = "idleConn"
+	addressFieldName      = "addr"
+	unkHttpClientName     = "Other"
+	defaultHttpClientName = "Default"
+)
+
+type HTTPMetrics struct {
+	client *http.Client
+}
+
+func GetHttpMetricMiddleware(client *http.Client) *HTTPMetrics {
+	return &HTTPMetrics{
+		client: client,
+	}
+}
+
+func (m *HTTPMetrics) ID() string {
+	return "HTTPMetrics"
+}
+
+func (m *HTTPMetrics) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, metadata middleware.Metadata, attemptError error,
+) {
+	ctx = m.addTraceContext(ctx)
+	finalize, metadata, err := next.HandleFinalize(ctx, in)
+	return finalize, metadata, err
+}
+
+var addClientTrace = func(ctx context.Context, trace *httptrace.ClientTrace) context.Context {
+	return httptrace.WithClientTrace(ctx, trace)
+}
+
+func (m *HTTPMetrics) addTraceContext(ctx context.Context) context.Context {
+	mctx := awsmetrics.Context(ctx)
+	counter := mctx.ConnectionCounter()
+
+	attemptMetrics, attemptErr := mctx.Data().LatestAttempt()
+
+	if attemptErr == nil {
+		trace := &httptrace.ClientTrace{
+			GotFirstResponseByte: func() {
+				gotFirstResponseByte(attemptMetrics, time.Now().UTC())
+			},
+			GetConn: func(hostPort string) {
+				getConn(attemptMetrics, counter, time.Now().UTC(), m.client, hostPort)
+			},
+			GotConn: func(info httptrace.GotConnInfo) {
+				gotConn(attemptMetrics, counter, info, time.Now())
+			},
+		}
+
+		ctx = addClientTrace(ctx, trace)
+	} else {
+		fmt.Println(attemptErr)
+	}
+	return ctx
+}
+
+func gotFirstResponseByte(attemptMetrics *awsmetrics.AttemptMetrics, now time.Time) {
+	attemptMetrics.FirstByteTime = now
+}
+
+func getConn(
+	attemptMetrics *awsmetrics.AttemptMetrics, counter *awsmetrics.SharedConnectionCounter, now time.Time, client *http.Client, hostPort string,
+) {
+	attemptMetrics.ConnRequestedTime = now
+	attemptMetrics.PendingConnectionAcquires = int(counter.PendingConnectionAcquire())
+	attemptMetrics.ActiveRequests = int(counter.ActiveRequests())
+
+	// Adding HTTP client metrics here since we need the hostPort to identify the correct conn queues.
+	addHTTPClientMetrics(attemptMetrics, client, hostPort)
+	counter.AddPendingConnectionAcquire()
+}
+
+func gotConn(
+	attemptMetrics *awsmetrics.AttemptMetrics, counter *awsmetrics.SharedConnectionCounter, info httptrace.GotConnInfo, now time.Time,
+) {
+	attemptMetrics.ReusedConnection = info.Reused
+	attemptMetrics.ConnObtainedTime = now
+	counter.RemovePendingConnectionAcquire()
+}
+
+func addHTTPClientMetrics(attemptMetrics *awsmetrics.AttemptMetrics, client *http.Client, hostPort string) {
+
+	maxConnsPerHost := -1
+	idleConnCountPerHost := -1
+	httpClient := unkHttpClientName
+
+	clientInterface := interface{}(client)
+
+	switch clientInterface.(type) {
+	// If not a standard HTTP client we cannot retrieve these metrics
+	case *http.Client:
+		transport := clientInterface.(*http.Client).Transport
+		httpClient = defaultHttpClientName
+		switch transport.(type) {
+		case *http.Transport:
+
+			maxConnsPerHost = transport.(*http.Transport).MaxConnsPerHost
+
+			transportPtr := reflect.ValueOf(transport.(*http.Transport))
+
+			if transportPtr.IsValid() && transportPtr.Kind() == reflect.Pointer {
+
+				transportValue := transportPtr.Elem()
+				idleConn := transportValue.FieldByName(idleConnFieldName)
+
+				if idleConn.IsValid() && idleConn.Kind() == reflect.Map {
+
+					IdleConnMap := idleConn.MapRange()
+					// We iterate through all the connection queues to look for the target host
+					for IdleConnMap.Next() {
+						address := IdleConnMap.Key().FieldByName(addressFieldName)
+
+						if address.IsValid() && address.Kind() == reflect.String {
+
+							if address.String() == hostPort {
+								// Number of idle connections for the requests host
+								idleConnCountPerHost = IdleConnMap.Value().Len()
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	attemptMetrics.HTTPClient = httpClient
+	attemptMetrics.AvailableConcurrency = idleConnCountPerHost
+	attemptMetrics.MaxConcurrency = maxConnsPerHost
+}

--- a/v2/awsmetrics/middleware/identity.go
+++ b/v2/awsmetrics/middleware/identity.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+func timeGetIdentity(stack *middleware.Stack) error {
+	if err := stack.Finalize.Insert(getIdentityStart{}, "GetIdentity", middleware.Before); err != nil {
+		return err
+	}
+	if err := stack.Finalize.Insert(getIdentityEnd{}, "GetIdentity", middleware.After); err != nil {
+		return err
+	}
+	return nil
+}
+
+type getIdentityStart struct{}
+
+func (m getIdentityStart) ID() string { return "getIdentityStart" }
+
+func (m getIdentityStart) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, md middleware.Metadata, err error,
+) {
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().GetIdentityStartTime = time.Now().UTC()
+	return next.HandleFinalize(ctx, in)
+}
+
+type getIdentityEnd struct{}
+
+func (m getIdentityEnd) ID() string { return "getIdentityEnd" }
+
+func (m getIdentityEnd) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, md middleware.Metadata, err error,
+) {
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().GetIdentityEndTime = time.Now().UTC()
+	return next.HandleFinalize(ctx, in)
+}

--- a/v2/awsmetrics/middleware/metric_collection.go
+++ b/v2/awsmetrics/middleware/metric_collection.go
@@ -1,0 +1,65 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type MetricCollection struct {
+	cc        *awsmetrics.SharedConnectionCounter
+	publisher awsmetrics.MetricPublisher
+}
+
+func GetSetupMetricCollectionMiddleware(
+	counter *awsmetrics.SharedConnectionCounter, publisher awsmetrics.MetricPublisher,
+) *MetricCollection {
+	return &MetricCollection{
+		cc:        counter,
+		publisher: publisher,
+	}
+}
+
+func (m *MetricCollection) ID() string {
+	return "MetricCollection"
+}
+
+func (m *MetricCollection) HandleInitialize(
+	ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler,
+) (
+	out middleware.InitializeOutput, metadata middleware.Metadata, err error,
+) {
+
+	ctx = awsmetrics.InitMetricContext(ctx, m.cc, m.publisher)
+
+	mctx := awsmetrics.Context(ctx)
+	metricData := mctx.Data()
+
+	metricData.RequestStartTime = time.Now().UTC()
+
+	out, metadata, err = next.HandleInitialize(ctx, in)
+
+	metricData.RequestEndTime = time.Now().UTC()
+
+	if err == nil {
+		metricData.Success = 1
+	} else {
+		metricData.Success = 0
+	}
+
+	metricData.ComputeRequestMetrics()
+
+	publishErr := m.publisher.PostRequestMetrics(awsmetrics.Context(ctx).Data())
+	if publishErr != nil {
+		fmt.Println("Failed to post request metrics")
+	}
+
+	return out, metadata, err
+}

--- a/v2/awsmetrics/middleware/request.go
+++ b/v2/awsmetrics/middleware/request.go
@@ -1,0 +1,61 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+const (
+	clientRequestIdKey = "Amz-Sdk-Invocation-Id"
+	unkClientId        = "unk"
+)
+
+type RegisterMetricContext struct{}
+
+func GetRegisterRequestMetricContextMiddleware() *RegisterMetricContext {
+	return &RegisterMetricContext{}
+}
+
+func (m *RegisterMetricContext) ID() string {
+	return "RegisterMetricContext"
+}
+
+func (m *RegisterMetricContext) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+) {
+
+	mctx := awsmetrics.Context(ctx)
+	metricData := mctx.Data()
+
+	metricData.ServiceID = awsmiddleware.GetServiceID(ctx)
+	metricData.OperationName = awsmiddleware.GetOperationName(ctx)
+	metricData.PartitionID = awsmiddleware.GetPartitionID(ctx)
+	metricData.Region = awsmiddleware.GetSigningRegion(ctx)
+
+	switch req := in.Request.(type) {
+	case *smithyhttp.Request:
+		crid := req.Header.Get(clientRequestIdKey)
+		if len(crid) == 0 {
+			crid = unkClientId
+		}
+		metricData.ClientRequestID = crid
+		metricData.RequestContentLength = req.ContentLength
+	default:
+		metricData.ClientRequestID = unkClientId
+		metricData.RequestContentLength = -1
+	}
+
+	out, metadata, err = next.HandleFinalize(ctx, in)
+
+	return out, metadata, err
+}

--- a/v2/awsmetrics/middleware/request_attempt.go
+++ b/v2/awsmetrics/middleware/request_attempt.go
@@ -1,0 +1,70 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/smithy-go/middleware"
+	"github.com/aws/smithy-go/transport/http"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+const (
+	amznRequestIdKey  = "X-Amz-Request-Id"
+	amznRequestId2Key = "X-Amz-Id-2"
+	unkAmznReqId      = "unk"
+	unkAmznReqId2     = "unk"
+)
+
+type RegisterAttemptMetricContext struct{}
+
+func GetRegisterAttemptMetricContextMiddleware() *RegisterAttemptMetricContext {
+	return &RegisterAttemptMetricContext{}
+}
+
+func (m *RegisterAttemptMetricContext) ID() string {
+	return "RegisterAttemptMetricContext"
+}
+
+var getRawResponse = func(metadata middleware.Metadata) *http.Response {
+	switch res := awsmiddleware.GetRawResponse(metadata).(type) {
+	case *http.Response:
+		return res
+	default:
+		return nil
+	}
+}
+
+func (m *RegisterAttemptMetricContext) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+) {
+
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().NewAttempt()
+
+	out, metadata, err = next.HandleFinalize(ctx, in)
+
+	res := getRawResponse(metadata)
+
+	attemptMetrics, _ := mctx.Data().LatestAttempt()
+
+	if res != nil {
+		attemptMetrics.RequestID = res.Header.Get(amznRequestIdKey)
+		attemptMetrics.ExtendedRequestID = res.Header.Get(amznRequestId2Key)
+		attemptMetrics.StatusCode = res.StatusCode
+		attemptMetrics.ResponseContentLength = res.ContentLength
+	} else {
+		attemptMetrics.RequestID = unkAmznReqId
+		attemptMetrics.ExtendedRequestID = unkAmznReqId2
+		attemptMetrics.StatusCode = -1
+		attemptMetrics.ResponseContentLength = -1
+	}
+
+	return out, metadata, err
+}

--- a/v2/awsmetrics/middleware/signing.go
+++ b/v2/awsmetrics/middleware/signing.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+func timeSigning(stack *middleware.Stack) error {
+	if err := stack.Finalize.Insert(signingStart{}, "Signing", middleware.Before); err != nil {
+		return err
+	}
+	if err := stack.Finalize.Insert(signingEnd{}, "Signing", middleware.After); err != nil {
+		return err
+	}
+	return nil
+}
+
+type signingStart struct{}
+
+func (m signingStart) ID() string { return "signingStart" }
+
+func (m signingStart) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, md middleware.Metadata, err error,
+) {
+	mctx := awsmetrics.Context(ctx)
+	attempt, err := mctx.Data().LatestAttempt()
+	if err != nil {
+		return out, md, err
+	}
+
+	attempt.SignStartTime = time.Now().UTC()
+	return next.HandleFinalize(ctx, in)
+}
+
+type signingEnd struct{}
+
+func (m signingEnd) ID() string { return "signingEnd" }
+
+func (m signingEnd) HandleFinalize(
+	ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler,
+) (
+	out middleware.FinalizeOutput, md middleware.Metadata, err error,
+) {
+	mctx := awsmetrics.Context(ctx)
+	attempt, err := mctx.Data().LatestAttempt()
+	if err != nil {
+		return out, md, err
+	}
+
+	attempt.SignEndTime = time.Now().UTC()
+	return next.HandleFinalize(ctx, in)
+}

--- a/v2/awsmetrics/middleware/stack_deserialize_end.go
+++ b/v2/awsmetrics/middleware/stack_deserialize_end.go
@@ -1,0 +1,46 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type StackDeserializeEnd struct{}
+
+func GetRecordStackDeserializeEndMiddleware() *StackDeserializeEnd {
+	return &StackDeserializeEnd{}
+}
+
+func (m *StackDeserializeEnd) ID() string {
+	return "StackDeserializeEnd"
+}
+
+func (m *StackDeserializeEnd) HandleDeserialize(
+	ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler,
+) (
+	out middleware.DeserializeOutput, metadata middleware.Metadata, attemptErr error,
+) {
+
+	out, metadata, err := next.HandleDeserialize(ctx, in)
+
+	mctx := awsmetrics.Context(ctx)
+
+	attemptMetrics, attemptErr := mctx.Data().LatestAttempt()
+
+	if attemptErr != nil {
+		fmt.Println(attemptErr)
+	} else {
+		attemptMetrics.DeserializeEndTime = time.Now().UTC()
+	}
+
+	return out, metadata, err
+
+}

--- a/v2/awsmetrics/middleware/stack_deserialize_start.go
+++ b/v2/awsmetrics/middleware/stack_deserialize_start.go
@@ -1,0 +1,45 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type StackDeserializeStart struct{}
+
+func GetRecordStackDeserializeStartMiddleware() *StackDeserializeStart {
+	return &StackDeserializeStart{}
+}
+
+func (m *StackDeserializeStart) ID() string {
+	return "StackDeserializeStart"
+}
+
+func (m *StackDeserializeStart) HandleDeserialize(
+	ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler,
+) (
+	out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
+) {
+
+	out, metadata, err = next.HandleDeserialize(ctx, in)
+
+	mctx := awsmetrics.Context(ctx)
+
+	attemptMetrics, attemptErr := mctx.Data().LatestAttempt()
+
+	if attemptErr != nil {
+		fmt.Println(err)
+	} else {
+		attemptMetrics.DeserializeStartTime = time.Now().UTC()
+	}
+
+	return out, metadata, err
+}

--- a/v2/awsmetrics/middleware/stack_serialize_end.go
+++ b/v2/awsmetrics/middleware/stack_serialize_end.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type StackSerializeEnd struct{}
+
+func GetRecordStackSerializeEndMiddleware() *StackSerializeEnd {
+	return &StackSerializeEnd{}
+}
+
+func (m *StackSerializeEnd) ID() string {
+	return "StackSerializeEnd"
+}
+
+func (m *StackSerializeEnd) HandleSerialize(
+	ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler,
+) (
+	out middleware.SerializeOutput, metadata middleware.Metadata, err error,
+) {
+
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().SerializeEndTime = time.Now().UTC()
+
+	out, metadata, err = next.HandleSerialize(ctx, in)
+
+	return out, metadata, err
+
+}

--- a/v2/awsmetrics/middleware/stack_serialize_start.go
+++ b/v2/awsmetrics/middleware/stack_serialize_start.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type StackSerializeStart struct{}
+
+func GetRecordStackSerializeStartMiddleware() *StackSerializeStart {
+	return &StackSerializeStart{}
+}
+
+func (m *StackSerializeStart) ID() string {
+	return "StackSerializeStart"
+}
+
+func (m *StackSerializeStart) HandleSerialize(
+	ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler,
+) (
+	out middleware.SerializeOutput, metadata middleware.Metadata, err error,
+) {
+
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().SerializeStartTime = time.Now().UTC()
+
+	out, metadata, err = next.HandleSerialize(ctx, in)
+
+	return out, metadata, err
+}

--- a/v2/awsmetrics/middleware/transport.go
+++ b/v2/awsmetrics/middleware/transport.go
@@ -1,0 +1,47 @@
+// This package is designated as private and is intended for use only by the
+// smithy client runtime. The exported API therein is not considered stable and
+// is subject to breaking changes without notice.
+
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type TransportMetrics struct{}
+
+func GetTransportMetricsMiddleware() *TransportMetrics {
+	return &TransportMetrics{}
+}
+
+func (m *TransportMetrics) ID() string {
+	return "TransportMetrics"
+}
+
+func (m *TransportMetrics) HandleDeserialize(
+	ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler,
+) (
+	out middleware.DeserializeOutput, metadata middleware.Metadata, attemptErr error,
+) {
+
+	mctx := awsmetrics.Context(ctx)
+
+	if attempt, e := mctx.Data().LatestAttempt(); e == nil {
+		attempt.ServiceCallStart = time.Now().UTC()
+		mctx.ConnectionCounter().AddActiveRequest()
+	}
+
+	out, metadata, err := next.HandleDeserialize(ctx, in)
+
+	if attempt, e := mctx.Data().LatestAttempt(); e == nil {
+		attempt.ServiceCallEnd = time.Now().UTC()
+		mctx.ConnectionCounter().RemoveActiveRequest()
+	}
+
+	return out, metadata, err
+
+}

--- a/v2/awsmetrics/middleware/user_agent.go
+++ b/v2/awsmetrics/middleware/user_agent.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type captureUserAgent struct{}
+
+func (*captureUserAgent) ID() string { return "captureUserAgent" }
+
+func (*captureUserAgent) HandleBuild(
+	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
+) (
+	out middleware.BuildOutput, md middleware.Metadata, err error,
+) {
+	r, ok := in.Request.(*smithyhttp.Request)
+	if !ok {
+		return out, md, fmt.Errorf("unexpected transport type %T", in.Request)
+	}
+
+	mctx := awsmetrics.Context(ctx)
+	mctx.Data().UserAgent = r.Header.Get("User-Agent")
+	return next.HandleBuild(ctx, in)
+}

--- a/v2/awsmetrics/middleware/wrap_data_stream.go
+++ b/v2/awsmetrics/middleware/wrap_data_stream.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"context"
+	"io"
+	"reflect"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics/readcloserwithmetrics"
+)
+
+const (
+	responseBodyFieldName = "Body"
+)
+
+type WrapDataContext struct{}
+
+func GetWrapDataStreamMiddleware() *WrapDataContext {
+	return &WrapDataContext{}
+}
+
+func (m *WrapDataContext) ID() string {
+	return "BuildWrapDataStream"
+}
+
+func (m *WrapDataContext) HandleBuild(
+	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
+) (
+	out middleware.BuildOutput, metadata middleware.Metadata, err error,
+) {
+
+	out, metadata, err = next.HandleBuild(ctx, in)
+
+	value := reflect.ValueOf(out.Result)
+
+	if value.Kind() != reflect.Ptr {
+		return out, metadata, err
+	}
+	value = value.Elem()
+
+	if value.Kind() != reflect.Struct {
+		return out, metadata, err
+	}
+	bodyField := value.FieldByName(responseBodyFieldName)
+
+	if !(bodyField.IsValid() && bodyField.CanInterface()) {
+		return out, metadata, err
+	}
+
+	body, ok := bodyField.Interface().(io.ReadCloser)
+
+	if !ok {
+		return out, metadata, err
+	}
+
+	bodyField.Set(reflect.ValueOf(readcloserwithmetrics.New(awsmetrics.Context(ctx), body)))
+
+	return out, metadata, err
+}

--- a/v2/awsmetrics/readcloserwithmetrics/read_closer_with_metrics.go
+++ b/v2/awsmetrics/readcloserwithmetrics/read_closer_with_metrics.go
@@ -1,0 +1,57 @@
+package readcloserwithmetrics
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type ReadCloserWithMetrics struct {
+	data         *awsmetrics.MetricData
+	publisher    awsmetrics.MetricPublisher
+	readCloser   io.ReadCloser
+	readFinished bool
+}
+
+func New(
+	context *awsmetrics.MetricContext, closer io.ReadCloser,
+) (trc *ReadCloserWithMetrics) {
+	return &ReadCloserWithMetrics{
+		data:         context.Data(),
+		publisher:    context.Publisher(),
+		readCloser:   closer,
+		readFinished: false,
+	}
+}
+
+func (r *ReadCloserWithMetrics) Read(p []byte) (n int, err error) {
+	readRoundStarted := time.Now().UTC()
+	read, err := r.readCloser.Read(p)
+	readRoundEnd := time.Now().UTC()
+	r.data.Stream.ReadDuration += readRoundEnd.Sub(readRoundStarted)
+	r.data.Stream.ReadBytes += int64(read)
+	if err == io.EOF {
+		r.readFinished = true
+		r.finalize()
+	}
+	return read, err
+}
+
+func (r *ReadCloserWithMetrics) Close() error {
+	if !r.readFinished {
+		r.finalize()
+	}
+	return r.readCloser.Close()
+}
+
+func (r *ReadCloserWithMetrics) finalize() {
+	if r.data.Stream.ReadDuration > 0 {
+		r.data.Stream.Throughput = float64(r.data.Stream.ReadBytes) / r.data.Stream.ReadDuration.Seconds()
+	}
+	err := r.publisher.PostStreamMetrics(r.data)
+	if err != nil {
+		fmt.Println("Failed to post stream metrics")
+	}
+}

--- a/v2/awsmetrics/testutils/test_util.go
+++ b/v2/awsmetrics/testutils/test_util.go
@@ -1,0 +1,111 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+)
+
+type MetricDataRecorderPublisher struct {
+	Data *awsmetrics.MetricData
+}
+
+func (mdrp *MetricDataRecorderPublisher) PostRequestMetrics(data *awsmetrics.MetricData) error {
+	mdrp.Data = data
+	return nil
+}
+
+func (mdrp *MetricDataRecorderPublisher) PostStreamMetrics(data *awsmetrics.MetricData) error {
+	mdrp.Data = data
+	return nil
+}
+
+type NoopPublisher struct{}
+
+func (np *NoopPublisher) PostRequestMetrics(data *awsmetrics.MetricData) error {
+	return nil
+}
+
+func (np *NoopPublisher) PostStreamMetrics(data *awsmetrics.MetricData) error {
+	return nil
+}
+
+type ErrorPublisher struct{}
+
+func (tp *ErrorPublisher) PostRequestMetrics(data *awsmetrics.MetricData) error {
+	return fmt.Errorf("publisher error")
+}
+
+func (tp *ErrorPublisher) PostStreamMetrics(data *awsmetrics.MetricData) error {
+	return fmt.Errorf("publisher error")
+}
+
+type NoopInitializeHandler struct{}
+type ErrorInitializeHandler struct{}
+type NoopSerializeHandler struct{}
+type NoopFinalizeHandler struct{}
+type NoopDeserializeHandler struct{}
+type StreamingBodyBuildHandler struct {
+	Result interface{}
+}
+
+func NoopRequestCloner(i interface{}) interface{} {
+	return i
+}
+
+func (NoopInitializeHandler) HandleInitialize(ctx context.Context, in middleware.InitializeInput) (
+	out middleware.InitializeOutput, metadata middleware.Metadata, err error,
+) {
+	return middleware.InitializeOutput{}, middleware.Metadata{}, nil
+}
+
+func (ErrorInitializeHandler) HandleInitialize(ctx context.Context, in middleware.InitializeInput) (
+	out middleware.InitializeOutput, metadata middleware.Metadata, err error,
+) {
+	return middleware.InitializeOutput{}, middleware.Metadata{}, fmt.Errorf("init error")
+}
+
+func (NoopFinalizeHandler) HandleFinalize(ctx context.Context, in middleware.FinalizeInput) (
+	out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+) {
+	return middleware.FinalizeOutput{}, middleware.Metadata{}, nil
+}
+
+func (NoopDeserializeHandler) HandleDeserialize(ctx context.Context, in middleware.DeserializeInput) (
+	out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
+) {
+	return middleware.DeserializeOutput{}, middleware.Metadata{}, nil
+}
+
+func (NoopSerializeHandler) HandleSerialize(ctx context.Context, in middleware.SerializeInput) (
+	out middleware.SerializeOutput, metadata middleware.Metadata, err error,
+) {
+	return middleware.SerializeOutput{}, middleware.Metadata{}, nil
+}
+
+func (s *StreamingBodyBuildHandler) HandleBuild(ctx context.Context, in middleware.BuildInput) (
+	out middleware.BuildOutput, metadata middleware.Metadata, err error,
+) {
+	return middleware.BuildOutput{Result: s.Result}, middleware.Metadata{}, nil
+}
+
+type TestReadCloser struct {
+	Data   []byte
+	offset int
+}
+
+func (m *TestReadCloser) Read(p []byte) (int, error) {
+	if m.offset >= len(m.Data) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.Data[m.offset:])
+	m.offset += n
+	return n, nil
+}
+
+func (m *TestReadCloser) Close() error {
+	return nil
+}

--- a/v2/v2.go
+++ b/v2/v2.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/middleware/private/metrics"
-	"github.com/aws/aws-sdk-go-v2/aws/middleware/private/metrics/middleware"
 	smithy "github.com/aws/smithy-go/middleware"
 	"github.com/jonathan-innis/aws-sdk-go-prometheus/common"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics"
+	"github.com/jonathan-innis/aws-sdk-go-prometheus/v2/awsmetrics/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -38,7 +38,7 @@ func NewPrometheusPublisher(r prometheus.Registerer) *PrometheusPublisher {
 }
 
 // PostRequestMetrics publishes request metrics to the prometheus registry.
-func (p *PrometheusPublisher) PostRequestMetrics(data *metrics.MetricData) error {
+func (p *PrometheusPublisher) PostRequestMetrics(data *awsmetrics.MetricData) error {
 	common.TotalRequests.With(common.RequestLabels(data.ServiceID, data.OperationName, data.StatusCode)).Inc()
 	common.RequestLatency.With(common.RequestLabels(data.ServiceID, data.OperationName, data.StatusCode)).Observe(float64(data.APICallDuration.Milliseconds()) / 1000.0)
 	common.RetryCount.With(common.RequestLabels(data.ServiceID, data.OperationName, data.StatusCode)).Observe(float64(data.RetryCount))
@@ -51,7 +51,7 @@ func (p *PrometheusPublisher) PostRequestMetrics(data *metrics.MetricData) error
 }
 
 // PostStreamMetrics publishes the stream metrics to the prometheus registry.
-func (p *PrometheusPublisher) PostStreamMetrics(data *metrics.MetricData) error {
+func (p *PrometheusPublisher) PostStreamMetrics(data *awsmetrics.MetricData) error {
 	common.TotalRequests.With(common.RequestLabels(data.ServiceID, data.OperationName, data.StatusCode)).Inc()
 	return nil
 }


### PR DESCRIPTION
AWS has removed the `private` package (in https://github.com/aws/aws-sdk-go-v2/pull/2818) on which this repository depends.

As a fix, this change brings the metrics middleware removed from `aws-sdk-go-v2` into this repo, and uses it. The metrics exposed remain the same.